### PR TITLE
storage Delete impl

### DIFF
--- a/data/storage/file.go
+++ b/data/storage/file.go
@@ -73,6 +73,12 @@ func (adp *fileStorage) Read(filename string) ([]byte, error) {
 	return ioutil.ReadAll(reader)
 }
 
+// Delete will delete file from the file systems.
+func (adp *fileStorage) Delete(filename string) error {
+	path := adp.dsn.Join(filename)
+	return os.Remove(path)
+}
+
 // Merge will merge file into the file systems.
 func (adp *fileStorage) Merge(filename string, data []byte) error {
 	head, _ := adp.Read(filename)

--- a/data/storage/s3.go
+++ b/data/storage/s3.go
@@ -97,6 +97,15 @@ func (adp *s3Storage) Read(filename string) ([]byte, error) {
 	return data, err
 }
 
+// Delete will delete file from the file systems.
+func (adp *s3Storage) Delete(filename string) error {
+	_, err := s3.New(adp.dsn.Sess).DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(adp.dsn.Bucket),
+		Key:    aws.String(adp.dsn.Join(filename)),
+	})
+	return err
+}
+
 // Merge will merge file into the s3
 func (adp *s3Storage) Merge(filename string, data []byte) error {
 	head, _ := adp.Read(filename)

--- a/data/storage/storage.go
+++ b/data/storage/storage.go
@@ -18,6 +18,7 @@ type (
 	Storage interface {
 		Write(filename string, data []byte) error
 		Read(filename string) ([]byte, error)
+		Delete(filename string) error
 		Merge(filename string, data []byte) error
 		Files(ptn string) ([]string, error)
 		URL(filename string) string


### PR DESCRIPTION
blogの削除時に、blog_imageのstorage側も削除したほうが良いかと思い、こちらの実装を追加しました。