### PR TITLE
follow semantic-convention in sentry-slowquery 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,8 @@ require (
 	google.golang.org/grpc v1.40.0
 )
 
+require github.com/spf13/cast v1.4.1
+
 require (
 	cloud.google.com/go v0.93.3 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
@@ -53,7 +55,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/spf13/cast v1.4.1 // indirect
 	github.com/volatiletech/inflect v0.0.1 // indirect
 	github.com/volatiletech/strmangle v0.0.1 // indirect
 	go.opencensus.io v0.23.0 // indirect

--- a/util/conn.go
+++ b/util/conn.go
@@ -85,7 +85,11 @@ func DBSlowQuery(dialect string, period time.Duration) {
 
 					data := map[string]interface{}{}
 					for _, arg := range args {
-						data[arg.Name] = cast.ToString(arg.Value)
+						k := arg.Name
+						if k == "" {
+							k = cast.ToString(arg.Ordinal)
+						}
+						data[k] = cast.ToString(arg.Value)
 					}
 					s.Data = data
 				})
@@ -111,7 +115,11 @@ func DBSlowQuery(dialect string, period time.Duration) {
 
 					data := map[string]interface{}{}
 					for _, arg := range args {
-						data[arg.Name] = cast.ToString(arg.Value)
+						k := arg.Name
+						if k == "" {
+							k = cast.ToString(arg.Ordinal)
+						}
+						data[k] = cast.ToString(arg.Value)
 					}
 					s.Data = data
 				})


### PR DESCRIPTION
- https://github.com/getsentry/sentry-ruby/issues/1674
- https://develop.sentry.dev/sdk/performance/span-operations/#database
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md


```json
    {
      "trace_id": "029de2abdc61ec8e85c01ffd2dcbcd8e",
      "span_id": "662fd52430874e12",
      "op": "db.sql.query.slow",
      "description": "SELECT * FROM `project_activities` WHERE (`project_activities`.`project_id` IN (?));",
      "start_timestamp": "2022-06-10T20:26:32.413368+09:00",
      "timestamp": "2022-06-10T20:26:32.414143083+09:00",
      "data": {
        "1": "1"
      },
      "parent_span_id": "561d66a7bf1954c6"
    },
    {
      "trace_id": "029de2abdc61ec8e85c01ffd2dcbcd8e",
      "span_id": "cc7715057de2170c",
      "op": "db.sql.query.slow",
      "description": "SELECT * FROM `project_profiles` WHERE (`project_profiles`.`project_id` IN (?));",
      "start_timestamp": "2022-06-10T20:26:32.41397+09:00",
      "timestamp": "2022-06-10T20:26:32.41398475+09:00",
      "data": {
        "1": "1"
      },
      "parent_span_id": "561d66a7bf1954c6"
 
```