### PR TITLE
golang 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 references:
   go_image: &go_image
-    - image: cimg/go:1.20
+    - image: cimg/go:1.21
 
   default: &default
     working_directory: ~/go-core

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,8 +44,7 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
-    - depguard
+    # - depguard
     - dogsled
     # - dupl
     - errcheck
@@ -56,28 +55,25 @@ linters:
     - gocyclo
     # - gofmt
     # - goimports
-    - golint
+    - revive
     # - gomnd
     # - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     # - lll
     - misspell
     - nakedret
     - nolintlint
     - rowserrcheck
-    - scopelint
+    - exportloopref
     - staticcheck
-    - structcheck
     - megacheck
     - stylecheck
     - typecheck
     - unconvert
     # - unparam
     - unused
-    - varcheck
     # - whitespace
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 SHELL := /bin/bash
 TOOL_BIN_DIR  ?= $(shell go env GOPATH)/bin
-GOLANGCI_LINT_VERSION := 1.47.3
+GOLANGCI_LINT_VERSION := 1.54.2
 
 install-golangci-lint:  ## Install golangci-lint
 	@rm -f $(TOOL_BIN_DIR)/golangci-lint

--- a/data/search/search.go
+++ b/data/search/search.go
@@ -162,7 +162,7 @@ func (c *command) DeleteDocument(ctx context.Context, name string, id int) (*Res
 	return c.do(ctx, fn)
 }
 
-func (c *command) ListIndexNames(ctx context.Context) ([]string, error) {
+func (c *command) ListIndexNames(_ context.Context) ([]string, error) {
 	return c.ESClient.IndexNames()
 }
 

--- a/data/storage/file.go
+++ b/data/storage/file.go
@@ -24,7 +24,7 @@ type fileStorage struct {
 }
 
 // Write will create file into the file systems.
-func (adp *fileStorage) Write(ctx context.Context, filename string, data []byte) error {
+func (adp *fileStorage) Write(_ context.Context, filename string, data []byte) error {
 	filename = adp.dsn.Join(filename)
 	folder := filepath.Dir(filename)
 
@@ -53,7 +53,7 @@ func (adp *fileStorage) Write(ctx context.Context, filename string, data []byte)
 }
 
 // Read returns file data from the file systems.
-func (adp *fileStorage) Read(ctx context.Context, filename string) ([]byte, error) {
+func (adp *fileStorage) Read(_ context.Context, filename string) ([]byte, error) {
 	var reader io.ReadCloser
 
 	reader, err := os.Open(adp.dsn.Join(filename))
@@ -74,7 +74,7 @@ func (adp *fileStorage) Read(ctx context.Context, filename string) ([]byte, erro
 }
 
 // Delete will delete file from the file systems.
-func (adp *fileStorage) Delete(ctx context.Context, filename string) error {
+func (adp *fileStorage) Delete(_ context.Context, filename string) error {
 	path := adp.dsn.Join(filename)
 	return os.Remove(path)
 }
@@ -88,7 +88,7 @@ func (adp *fileStorage) Merge(ctx context.Context, filename string, data []byte)
 }
 
 // Files returns filename list which is traversing with glob from filesystem.
-func (adp *fileStorage) Files(ctx context.Context, ptn string) ([]string, error) {
+func (adp *fileStorage) Files(_ context.Context, ptn string) ([]string, error) {
 	matches, err := filepath.Glob(adp.dsn.Join(ptn))
 	if err != nil {
 		logger.Printf("Failed to retrieve list files %s", err)
@@ -99,12 +99,12 @@ func (adp *fileStorage) Files(ctx context.Context, ptn string) ([]string, error)
 }
 
 // URL returns a Public URL
-func (adp *fileStorage) URL(ctx context.Context, filename string) string {
+func (adp *fileStorage) URL(_ context.Context, filename string) string {
 	return adp.dsn.URL(filename)
 }
 
 // String returns a URI
-func (adp *fileStorage) String(ctx context.Context, filename string) string {
+func (adp *fileStorage) String(_ context.Context, filename string) string {
 	return adp.dsn.String(filename)
 }
 

--- a/data/storage/gcs.go
+++ b/data/storage/gcs.go
@@ -163,12 +163,12 @@ func (adp *gcsStorage) Files(ctx context.Context, ptn string) ([]string, error) 
 }
 
 // URL returns Public URL
-func (adp *gcsStorage) URL(ctx context.Context, filename string) string {
+func (adp *gcsStorage) URL(_ context.Context, filename string) string {
 	return adp.dsn.URL(filename)
 }
 
 // String returns a URI
-func (adp *gcsStorage) String(ctx context.Context, filename string) string {
+func (adp *gcsStorage) String(_ context.Context, filename string) string {
 	return adp.dsn.String(filename)
 }
 

--- a/data/storage/s3.go
+++ b/data/storage/s3.go
@@ -31,7 +31,7 @@ type s3Storage struct {
 }
 
 // Write will create file into the s3.
-func (adp *s3Storage) Write(ctx context.Context, filename string, data []byte) error {
+func (adp *s3Storage) Write(_ context.Context, filename string, data []byte) error {
 	var reader io.Reader = bytes.NewReader(data)
 
 	if gzipPtn.MatchString(filename) {
@@ -65,7 +65,7 @@ func (adp *s3Storage) Write(ctx context.Context, filename string, data []byte) e
 }
 
 // Read returns file data from the s3
-func (adp *s3Storage) Read(ctx context.Context, filename string) ([]byte, error) {
+func (adp *s3Storage) Read(_ context.Context, filename string) ([]byte, error) {
 	file, err := os.CreateTemp("", "s3storage")
 	if err != nil {
 		return nil, xerrors.Errorf("[F] s3 read file failed: %w", err)
@@ -97,7 +97,7 @@ func (adp *s3Storage) Read(ctx context.Context, filename string) ([]byte, error)
 }
 
 // Delete will delete file from the file systems.
-func (adp *s3Storage) Delete(ctx context.Context, filename string) error {
+func (adp *s3Storage) Delete(_ context.Context, filename string) error {
 	_, err := s3.New(adp.dsn.Sess).DeleteObject(&s3.DeleteObjectInput{
 		Bucket: aws.String(adp.dsn.Bucket),
 		Key:    aws.String(adp.dsn.Join(filename)),
@@ -114,7 +114,7 @@ func (adp *s3Storage) Merge(ctx context.Context, filename string, data []byte) e
 }
 
 // Files returns filename list which is traversing with glob from s3 storage.
-func (adp *s3Storage) Files(ctx context.Context, ptn string) ([]string, error) {
+func (adp *s3Storage) Files(_ context.Context, ptn string) ([]string, error) {
 	base := strings.TrimLeft(adp.dsn.Join(ptn), "/")
 
 	g, err := glob.Compile(base)
@@ -150,17 +150,17 @@ func (adp *s3Storage) Files(ctx context.Context, ptn string) ([]string, error) {
 }
 
 // URL returns Public URL
-func (adp *s3Storage) URL(ctx context.Context, filename string) string {
+func (adp *s3Storage) URL(_ context.Context, filename string) string {
 	return adp.dsn.URL(filename)
 }
 
 // String returns a URI
-func (adp *s3Storage) String(ctx context.Context, filename string) string {
+func (adp *s3Storage) String(_ context.Context, filename string) string {
 	return adp.dsn.String(filename)
 }
 
 // PresignedUploadURL returns a presigned upload URI
-func (adp *s3Storage) PresignedUploadURL(ctx context.Context, filename string, expire time.Duration) (string, error) {
+func (adp *s3Storage) PresignedUploadURL(_ context.Context, filename string, expire time.Duration) (string, error) {
 	req, _ := s3.New(adp.dsn.Sess).PutObjectRequest(&s3.PutObjectInput{
 		Bucket: aws.String(adp.dsn.Bucket),
 		Key:    aws.String(adp.dsn.Join(filename)),
@@ -169,7 +169,7 @@ func (adp *s3Storage) PresignedUploadURL(ctx context.Context, filename string, e
 }
 
 // PresignedDownloadURL returns a presigned download URI
-func (adp *s3Storage) PresignedDownloadURL(ctx context.Context, filename string, expire time.Duration) (string, error) {
+func (adp *s3Storage) PresignedDownloadURL(_ context.Context, filename string, expire time.Duration) (string, error) {
 	req, _ := s3.New(adp.dsn.Sess).GetObjectRequest(&s3.GetObjectInput{
 		Bucket: aws.String(adp.dsn.Bucket),
 		Key:    aws.String(adp.dsn.Join(filename)),

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eiicon-company/go-core
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/bigquery v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ cloud.google.com/go/compute v1.13.0/go.mod h1:5aPTS0cUNMIc1CE546K+Th6weJUNQErARy
 cloud.google.com/go/compute/metadata v0.2.1 h1:efOwf5ymceDhK6PKMnnrTHP4pppY5L22mle96M1yP48=
 cloud.google.com/go/compute/metadata v0.2.1/go.mod h1:jgHgmJd2RKBGzXqF5LR2EZMGxBkeanZ9wwa75XHJgOM=
 cloud.google.com/go/datacatalog v1.8.0 h1:6kZ4RIOW/uT7QWC5SfPfq/G8sYzr/v+UOmOAxy4Z1TE=
+cloud.google.com/go/datacatalog v1.8.0/go.mod h1:KYuoVOv9BM8EYz/4eMFxrr4DUKhGIOXxZoKYF5wdISM=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
@@ -45,6 +46,7 @@ cloud.google.com/go/firestore v1.6.0/go.mod h1:afJwI0vaXwAG54kI7A//lP/lSPDkQORQu
 cloud.google.com/go/iam v0.10.0 h1:fpP/gByFs6US1ma53v7VxhvbJpO2Aapng6wabJ99MuI=
 cloud.google.com/go/iam v0.10.0/go.mod h1:nXAECrMt2qHpF6RZUZseteD6QyanL68reN4OXPw0UWM=
 cloud.google.com/go/longrunning v0.3.0 h1:NjljC+FYPV3uh5/OwWT6pVU+doBqMg2x/rZlE+CamDs=
+cloud.google.com/go/longrunning v0.3.0/go.mod h1:qth9Y41RRSUE69rDcOn6DdK3HfQfsUI0YSmW3iIlLJc=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -137,6 +139,7 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/friendsofgo/errors v0.9.2 h1:X6NYxef4efCBdwI7BgS820zFaN7Cphrmb+Pljdzjtgk=
 github.com/friendsofgo/errors v0.9.2/go.mod h1:yCvFW5AkDIL9qn7suHVLiI/gH228n7PC4Pn44IGoTOI=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -341,9 +344,11 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/util/logger/sentry_integration.go
+++ b/util/logger/sentry_integration.go
@@ -37,7 +37,7 @@ func (t *SentryDevNullTransport) SendEvent(event *sentry.Event) {
 }
 
 // Flush ...
-func (t *SentryDevNullTransport) Flush(timeout time.Duration) bool {
+func (t *SentryDevNullTransport) Flush(_ time.Duration) bool {
 	return true
 }
 
@@ -54,7 +54,7 @@ func (it *SentryLoggerIntegration) SetupOnce(client *sentry.Client) {
 	client.AddEventProcessor(it.processor)
 }
 
-func (it *SentryLoggerIntegration) processor(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+func (it *SentryLoggerIntegration) processor(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 	for _, thread := range event.Threads {
 		if thread.Stacktrace == nil {
 			continue

--- a/util/testdb/mysql.go
+++ b/util/testdb/mysql.go
@@ -67,11 +67,7 @@ func (m *mysqlTester) Teardown() error {
 		}
 	}
 
-	if err := m.dropDB(); err != nil {
-		return err
-	}
-
-	return nil
+	return m.dropDB()
 }
 
 // StdinCommand execs database


### PR DESCRIPTION
In addition, golangci-lint would be migrated into latest one with following fixes.

```
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner. Replaced by revive.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner. Replaced by exportloopref.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
```