### PR TITLE
Add headers param into smtp mail interface

### DIFF
--- a/data/mail/mail.go
+++ b/data/mail/mail.go
@@ -16,6 +16,7 @@ type (
 		Subject string
 		Text    []byte
 		HTML    []byte
+		Headers map[string][]string
 	}
 
 	// Mail provides interface for sends some of kinda E-Mail.

--- a/data/mail/smtp.go
+++ b/data/mail/smtp.go
@@ -22,6 +22,7 @@ func (m *smtpMail) Send(data *Data) error {
 	e.Cc = data.Cc
 	e.From = data.From
 	e.Subject = data.Subject
+	e.Headers = data.Headers
 	if data.Text != nil {
 		e.Text = data.Text
 	}


### PR DESCRIPTION
https://support.google.com/a/answer/81126?sjid=4068263634946002854-AP&visit_id=638412340927432952-240347523&rd=1#subscriptions

こちらのList-Unsubscribe ヘッダーに対応したい。

> 1 日に 5,000 件を超える[マーケティング目的のメールや配信登録されたメールを送信する場合は、ワンクリックでの登録解除に対応する必要があります](https://support.google.com/a/answer/81126?sjid=4068263634946002854-AP&visit_id=638412340927432952-240347523&rd=1#requirements-5k)。
>
> ワンクリックでの登録解除を設定するには、送信メールに次の両方のヘッダーを含めます。
>
> List-Unsubscribe-Post: List-Unsubscribe=One-Click
> List-Unsubscribe: <https://solarmora.com/unsubscribe/example>
> 受信者がワンクリックで登録解除すると、次の POST リクエストが届きます。
>
> POST /unsubscribe/example HTTP/1.1
> Host: solarmora.com
> Content-Type: application/x-www-form-urlencoded
> Content-Length: 26
> List-Unsubscribe=One-Click"
> 
> 詳しくは、[RFC 2369](https://tools.ietf.org/html/rfc2369) および [RFC 8058](https://tools.ietf.org/html/rfc8058) の List-Unsubscribe: ヘッダーについての記事をご覧ください。