### PR TITLE
Use image libraries instead commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,36 +14,8 @@ references:
         sudo apt-get update && \
         sudo apt-get upgrade -y && \
         DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends \
-            autoconf \
-            automake \
-            ca-certificates \
             curl \
-            gifsicle \
-            htop \
-            libtool \
-            libvips-dev \
-            make \
-            nasm \
-            net-tools \
-            openssl \
-            pkg-config \
-            pngquant \
-            telnet \
-            unzip \
-            vim \
-            wget \
-        && \
-          sudo update-ca-certificates \
-        && \
-          cd /tmp && \
-          wget https://github.com/mozilla/mozjpeg/archive/v3.3.1.tar.gz && \
-          tar -zxvf v3.3.1.tar.gz && \
-          cd mozjpeg-3.3.1 && \
-          autoreconf -fiv && \
-          mkdir build && cd build && \
-          sh ../configure && \
-          sudo make install && \
-          sudo ln -s /opt/mozjpeg/bin/* /usr/local/bin/
+            make
 
     setup_environment_variable: &setup_environment_variable
       name: Environment settings

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/aws/aws-sdk-go v1.50.0
-	github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe
 	github.com/getsentry/sentry-go v0.26.0
 	github.com/go-redsync/redsync v1.4.2
 	github.com/go-sql-driver/mysql v1.7.1
@@ -59,7 +58,6 @@ require (
 	github.com/apache/arrow/go/v12 v12.0.1 // indirect
 	github.com/apache/thrift v0.19.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/friendsofgo/errors v0.9.2 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,10 +138,6 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+gqO04wryn5h75LSazbRlnya1k=
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
-github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
-github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
-github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe h1:69JI97HlzP+PH5Mi1thcGlDoBr6PS2Oe+l3mNmAkbs4=
-github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe/go.mod h1:VQx0hjo2oUeQkQUET7wRwradO6f+fN5jzXgB/zROxxE=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/util/image/optimum/optimize.go
+++ b/util/image/optimum/optimize.go
@@ -37,7 +37,7 @@ func Optimize(buf []byte) ([]byte, error) {
 	}
 }
 
-// OptimizeGIFReader re-encodes GIF without external tools
+// OptimizeGIFReader reduce GIF size
 func OptimizeGIFReader(reader io.Reader) ([]byte, error) {
 	img, _, err := image.Decode(reader)
 	if err != nil {
@@ -53,7 +53,7 @@ func OptimizeGIFReader(reader io.Reader) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// OptimizeGIF re-encodes GIF without external tools
+// OptimizeGIF reduce GIF size
 func OptimizeGIF(buf []byte) ([]byte, error) {
 	return OptimizeGIFReader(bytes.NewReader(buf))
 }

--- a/util/image/optimum/optimize_test.go
+++ b/util/image/optimum/optimize_test.go
@@ -2,77 +2,60 @@ package optimum
 
 import (
 	"os"
-	"os/exec"
 	"testing"
 )
 
 func TestOptimizeALL(t *testing.T) {
-	if _, err := exec.LookPath(gifOptimizer); err == nil {
-		buf, err := os.ReadFile(testGIF)
-		if err != nil {
-			t.Fatalf("OptimizeGIF Error: file=%#+v: %+v", testGIF, err)
-		}
-
-		out, err := Optimize(buf)
-		if err != nil {
-			t.Fatalf("OptimizeGIF Error: file=%#+v: %+v", testGIF, err)
-		}
-
-		if len(out) <= 500 {
-			t.Fatalf("OptimizeGIF Error: file=%#+v something went wrong", testGIF)
-		}
-
-		_ = os.WriteFile("test-optimize-compressed.gif", out, 0600)
-	} else {
-		t.Logf("OptimizeGIF Skip: file=%#+v: %+v", testGIF, err)
+	buf, err := os.ReadFile(testGIF)
+	if err != nil {
+		t.Fatalf("OptimizeGIF Error: file=%#+v: %+v", testGIF, err)
 	}
 
-	if _, err := exec.LookPath(jpgOptimizer); err == nil {
-		buf, err := os.ReadFile(testJPG)
-		if err != nil {
-			t.Fatalf("OptimizeJPG Error: file=%#+v: %+v", testJPG, err)
-		}
-
-		out, err := Optimize(buf)
-		if err != nil {
-			t.Fatalf("OptimizeJPG Error: file=%#+v: %+v", testJPG, err)
-		}
-
-		if len(out) <= 500 {
-			t.Fatalf("OptimizeJPG Error: file=%#+v something went wrong", testGIF)
-		}
-
-		_ = os.WriteFile("test-optimize-compressed.jpg", out, 0600)
-	} else {
-		t.Logf("OptimizeJPG Skip: file=%#+v: %+v", testJPG, err)
+	out, err := Optimize(buf)
+	if err != nil {
+		t.Fatalf("OptimizeGIF Error: file=%#+v: %+v", testGIF, err)
 	}
 
-	if _, err := exec.LookPath(pngOptimizer); err == nil {
-		buf, err := os.ReadFile(testPNG)
-		if err != nil {
-			t.Fatalf("OptimizePNG Error: file=%#+v: %+v", testPNG, err)
-		}
-
-		out, err := Optimize(buf)
-		if err != nil {
-			t.Fatalf("OptimizePNG Error: file=%#+v: %+v", testPNG, err)
-		}
-
-		if len(out) <= 500 {
-			t.Fatalf("OptimizePNG Error: file=%#+v something went wrong", testGIF)
-		}
-
-		_ = os.WriteFile("test-optimize-compressed.png", out, 0600)
-	} else {
-		t.Logf("OptimizePNG Skip: file=%#+v: %+v", testPNG, err)
+	if len(out) <= 500 {
+		t.Fatalf("OptimizeGIF Error: file=%#+v something went wrong", testGIF)
 	}
+
+	_ = os.WriteFile("test-optimize-compressed.gif", out, 0600)
+
+	buf, err = os.ReadFile(testJPG)
+	if err != nil {
+		t.Fatalf("OptimizeJPG Error: file=%#+v: %+v", testJPG, err)
+	}
+
+	out, err = Optimize(buf)
+	if err != nil {
+		t.Fatalf("OptimizeJPG Error: file=%#+v: %+v", testJPG, err)
+	}
+
+	if len(out) <= 500 {
+		t.Fatalf("OptimizeJPG Error: file=%#+v something went wrong", testGIF)
+	}
+
+	_ = os.WriteFile("test-optimize-compressed.jpg", out, 0600)
+
+	buf, err = os.ReadFile(testPNG)
+	if err != nil {
+		t.Fatalf("OptimizePNG Error: file=%#+v: %+v", testPNG, err)
+	}
+
+	out, err = Optimize(buf)
+	if err != nil {
+		t.Fatalf("OptimizePNG Error: file=%#+v: %+v", testPNG, err)
+	}
+
+	if len(out) <= 500 {
+		t.Fatalf("OptimizePNG Error: file=%#+v something went wrong", testGIF)
+	}
+
+	_ = os.WriteFile("test-optimize-compressed.png", out, 0600)
 }
 
 func TestOptimizeGIF(t *testing.T) {
-	if _, err := exec.LookPath(gifOptimizer); err != nil {
-		t.Skipf("OptimizeGIF Skip: file=%#+v: %+v", testGIF, err)
-	}
-
 	f, err := os.Open(testGIF)
 	if err != nil {
 		t.Fatalf("OptimizeGIF Error: file=%#+v: %+v", testGIF, err)
@@ -91,10 +74,6 @@ func TestOptimizeGIF(t *testing.T) {
 }
 
 func TestOptimizeJPG(t *testing.T) {
-	if _, err := exec.LookPath(jpgOptimizer); err != nil {
-		t.Skipf("OptimizeJPG Skip: file=%#+v: %+v", testJPG, err)
-	}
-
 	f, err := os.Open(testJPG)
 	if err != nil {
 		t.Fatalf("OptimizeJPG Error: file=%#+v: %+v", testJPG, err)
@@ -113,10 +92,6 @@ func TestOptimizeJPG(t *testing.T) {
 }
 
 func TestOptimizePNG(t *testing.T) {
-	if _, err := exec.LookPath(pngOptimizer); err != nil {
-		t.Skipf("OptimizePNG Skip: file=%#+v: %+v", testPNG, err)
-	}
-
 	f, err := os.Open(testPNG)
 	if err != nil {
 		t.Fatalf("OptimizePNG Error: file=%#+v: %+v", testPNG, err)


### PR DESCRIPTION
画像のoptimizeに､外部コマンドを呼び出すのではなく標準ライブラリの `image/*` を使う｡
これにより､ランタイムの依存と実行コストを下げる｡