### PR TITLE
Update go to 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 references:
   go_image: &go_image
-    - image: cimg/go:1.22
+    - image: cimg/go:1.24
 
   default: &default
     working_directory: ~/go-core

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eiicon-company/go-core
 
-go 1.22
+go 1.24
 
 require (
 	cloud.google.com/go/bigquery v1.58.0


### PR DESCRIPTION
Goを1.22から1.24にアップデートする｡

> Fixes are prepared for the two most recent major releases and the head/master revision. Fixes are prepared for the two most recent major releases and merged to head/master.
https://go.dev/doc/security/policy