### PR TITLE
Update flake, envrc and CI

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,7 @@
 # set ft=sh
 
-if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.7; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.7/direnvrc" "sha256-bn8WANE5a91RusFmRI7kS751ApelG02nMcwRekC/qzc="
 fi
 
 use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
+
+    - uses: nixbuild/nix-quick-install-action@v30
       with:
-        extra-conf: |
+        nix_version: 2.26.1
+        nix_conf: |
+          substituters = https://cache.nixos.org
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          always-allow-substitutes = true
+          keep-env-derivations = true
+          keep-outputs = true
+          max-jobs = auto
           cores = 0
-    - uses: rrbutani/use-nix-shell-action@v1
+
+    - uses: nix-community/cache-nix-action@v6
       with:
-        devShell: .#
+        primary-key: v1-nix-cache-${{ runner.os }}-${{ github.event.repository.name }}-${{ hashFiles('flake.lock') }}
+        restore-prefixes-first-match: v1-nix-cache-${{ runner.os }}-${{ github.event.repository.name }}-
+
+    - uses: nicknovitski/nix-develop@v1
+      with:
+        arguments: .#
 
     - name: Lint
       run: |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 - [Direnv](https://direnv.net/)
 
 ### Runtime
-- mozjpeg
 - [mozjpeg](https://github.com/mozilla/mozjpeg)
 - [pngquant](https://github.com/kornelski/pngquant)
 - [gifsicle](https://github.com/kohler/gifsicle)

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
-        "revCount": 782401,
+        "lastModified": 1748162331,
+        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
+        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
+        "revCount": 802491,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.782401%2Brev-2631b0b7abcea6e640ce31cd78ea58910d31e650/01962c8a-63c4-7abd-a3df-63a17b548cc7/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.802491%2Brev-7c43f080a7f28b2774f3b3f43234ca11661bf334/01970886-40c4-7b8c-a32f-bb580ba9bcb1/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.0.tar.gz"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.0.tar.gz";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/*";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -37,7 +37,6 @@
 
           actionlint
 
-          circleci-cli
           nil # nix lsp
           nixfmt-rfc-style
         ];


### PR DESCRIPTION
nixpkgsを `0.1.0` から `*` にして､最新のstableを参照する｡
- もともと `0.1.0` にしたかったのはGo 1.24を使いたかったため｡最新の25.05にも含まれている

その他envrcとCIの設定